### PR TITLE
loosen (by one) the constraint on argument count when methos has varargs

### DIFF
--- a/src/main/java/com/budhash/cliche/CommandTable.java
+++ b/src/main/java/com/budhash/cliche/CommandTable.java
@@ -96,7 +96,7 @@ public class CommandTable {
         for (ShellCommand cs : collectedTable) {
             if (cs.getMethod().getParameterTypes().length == tokens.size()-1
                     || (cs.getMethod().isVarArgs()
-                        && (cs.getMethod().getParameterTypes().length <= tokens.size()-1))) {
+                        && (cs.getMethod().getParameterTypes().length <= tokens.size()))) {
                 reducedTable.add(cs);
             }
         }


### PR DESCRIPTION
 + the test is just with example.Example.add that returns '0' when invoked with no argument