### PR TITLE
Fixed two possible NPEs in case when ctrl-D is triggered

### DIFF
--- a/src/main/java/com/budhash/cliche/Shell.java
+++ b/src/main/java/com/budhash/cliche/Shell.java
@@ -243,7 +243,7 @@ public class Shell {
 		}
 		output.output(appName, outputConverter);
 		String command = "";
-		while (!command.trim().equals("exit")) {
+		while (command != null && !command.trim().equals("exit")) {
 			try {
 				command = input.readCommand(path);
 				processLine(command);
@@ -287,6 +287,10 @@ public class Shell {
 	 *             This may be TokenException
 	 */
 	public void processLine(String line) throws CLIException {
+	    if (line == null) {
+            return;
+        }
+
 		if (line.trim().equals("?")) {
 			output.output(String.format(HINT_FORMAT, appName), outputConverter);
 		} else {


### PR DESCRIPTION
Hi,

I'm building small REPL app and I found a problem with ctrl-D (Mac OS). In a Shell.java I have spot two places where NPE happened. Not sure I'm doing something wrong, but seems that two null checks are doing job well.